### PR TITLE
Add CC and use CFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: example checker
 CFLAGS=-g
 
 checker: confcheck.o
-	gcc -o confcheck confcheck.o -lconfig
+	$(CC) $(CFLAGS) -o confcheck confcheck.o -lconfig
 
 
 install: all
@@ -18,7 +18,7 @@ uninstall:
 	
 EG_OBJ=example.o parser.o argtable3.o
 example: $(EG_OBJ)
-	gcc -o example $(EG_OBJ) -lconfig
+	$(CC) $(CFLAGS) -o example $(EG_OBJ) -lconfig
 
 example.c: eg_conf.cfg
 	./conf2struct eg_conf.cfg


### PR DESCRIPTION
CC is necessary to specify the compiler to use (default to gcc) and use CFLAGS to specify compiler arguments