### PR TITLE
Use DESTDIR in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install: all
 	install -c confcheck $(DESTDIR)$(bindir)/confcheck
 
 uninstall:
-	rm -rf $(bindir)/conf2struct $(bindir)/confcheck
+	rm -rf $(DESTDIR)$(bindir)/conf2struct $(DESTDIR)$(bindir)/confcheck
 	
 EG_OBJ=example.o parser.o argtable3.o
 example: $(EG_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ checker: confcheck.o
 
 
 install: all
-	install -c conf2struct $(bindir)/conf2struct
-	install -c confcheck $(bindir)/confcheck
+	install -c conf2struct $(DESTDIR)$(bindir)/conf2struct
+	install -c confcheck $(DESTDIR)$(bindir)/confcheck
 
 uninstall:
 	rm -rf $(bindir)/conf2struct $(bindir)/confcheck


### PR DESCRIPTION
Follows the recommendations in the GNU standards; see https://www.gnu.org/prep/standards/html_node/DESTDIR.html

Required for Linux packaging.