### PR TITLE
Ensure executables are built before install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
 prefix=/usr/local
 bindir=$(prefix)/bin
 
-all: example checker
-
 CFLAGS=-g
 
-checker: confcheck.o
+all: example confcheck
+
+confcheck: confcheck.o
 	$(CC) $(CFLAGS) -o confcheck confcheck.o -lconfig
 
-
-install:
+install: conf2struct confcheck
 	mkdir -p $(DESTDIR)/$(bindir)
-	install -c conf2struct $(DESTDIR)$(bindir)/conf2struct
-	install -c confcheck $(DESTDIR)$(bindir)/confcheck
+	install -c -m 755 conf2struct $(DESTDIR)$(bindir)/conf2struct
+	install -c -m 755 confcheck $(DESTDIR)$(bindir)/confcheck
 
 uninstall:
 	rm -rf $(DESTDIR)$(bindir)/conf2struct $(DESTDIR)$(bindir)/confcheck


### PR DESCRIPTION
This adds confcheck (and conf2struct) as dependencies for the "install"
target (so that one can simply run `make install` to build and install the
tools).
